### PR TITLE
Update Complete Tableview after device change

### DIFF
--- a/GarminServiceKitUI/GarminServiceTableViewController.swift
+++ b/GarminServiceKitUI/GarminServiceTableViewController.swift
@@ -267,7 +267,7 @@ final class GarminServiceTableViewController: UITableViewController, UITextField
                 self.service.setActiveGarminDevice(device)
                 self.logger.debug("Selected device: \(device)")
             }
-            tableView.reloadRows(at: [indexPath], with: .automatic)
+            tableView.reloadData()
         case .sendtestdata:
             
             if let app = self.service.app {


### PR DESCRIPTION
Hej Jan,

my first pull request ever hope everything works out :) 

While using the extension with multiple devices I noticed that the device list updated only one row when choosing devices.

But its necessary to update the status of the second device as well (untick)

was really confusing as I was not sure which device is active.

This should fix the list view by using reloadData()

Im not sure if that's the right usage of reloadData but it works

Greetings Max
